### PR TITLE
Fix image links in Overview and Architecture sections

### DIFF
--- a/en/architecture.adoc
+++ b/en/architecture.adoc
@@ -1,3 +1,5 @@
+:imagesdir: img
+
 == Architecture
 
 Brief description of achitecture with goals/principles.
@@ -6,7 +8,7 @@ Source data for this project includes the National Human Settlement Layers (phys
 
 [#image-architecture]
 .OpenDRR Architecture Overview
-image::img/opendrr-architecture.png[OpenDRR Architecture Overview,float="",align="center"]
+image::opendrr-architecture.png[OpenDRR Architecture Overview,float="",align="center"]
 
 === Data Processing Pipeline
 
@@ -14,7 +16,7 @@ The OpenDRR platform data processing pipeline is responsible for extracting, tra
 
 [#image-etl]
 .OpenDRR Data Processing Pipeline
-image::img/opendrr-etl.png[OpenDRR Data Processing Pipeline, 600,align="center"]
+image::opendrr-etl.png[OpenDRR Data Processing Pipeline, 600,align="center"]
 
 The stack of technologies can be configured to run on a local machine with PostgreSQL and ElasticSearch environments running locally or can be configured to communicate with cloud deployments of these services. For example, the stack can be configured to communicate simultaneously with a PostgreSQL database on Amazon Web Services (AWS) Relational Database Service (RDS) and a Containerized ElasticSearch environment on an AWS Elastic Container Service (ECS). A common use case is to run the ETL process on a local desktop or AWS Elastic Compute Cloud (EC2) with a local containerized PostgreSQL environment and a cloud deployed ElasticSearch environment which can support a public or private application programming interface (API).
 
@@ -35,10 +37,10 @@ These results are aggregated at several different spatial scales, building, saui
 
 [#image-apis]
 .OpenDRR API Stack
-image::img/opendrr-apis.png[OpenDRR API Stack, 400]
+image::opendrr-apis.png[OpenDRR API Stack, 400]
 
 ==== Application Stack
 
 [#image-apps]
 .OpenDRR Application Stack
-image::img/opendrr-apps.png[OpenDRR Application Stack, 300]
+image::opendrr-apps.png[OpenDRR Application Stack, 300]

--- a/en/overview.adoc
+++ b/en/overview.adoc
@@ -14,7 +14,7 @@ Built in features of GitHub such as continuous integration and deployment, commu
 
 [#image-github]
 .OpenDRR GitHub
-image::opendrr-GitHub-en.png[OpenDRR GitHub]
+image::opendrr-github-en.png[OpenDRR GitHub]
 
 [.text-justify]
 Due to the diversity of use cases and user profiles for the information products (e.g.: maps, visualizations) it was clear that a single solution would not be sufficient. It was determined that a purpose built web application in addition to a customizable dashboard environment would likely meet the needs of all users.
@@ -23,12 +23,12 @@ The dashboard environment is provided by Kibanafootnote:[https://dashboard.riskp
 
 [#image-kibana]
 .OpenDRR Kibana
-image::img/opendrr-kibana.png[OpenDRR Kibana, 300]
+image::opendrr-kibana.png[OpenDRR Kibana, 300]
 
 The purpose built application, called RiskProfilerfootnote:[https://riskprofiler.ca], is a custom web application that connects to a variety of services including the Elasticsearch document store. Built to be highly scalable and user friendly, it seeks to communicate the key messages relating to natural hazard risk. It provides for some basic filtering and visualization in an area of interest, such as a community or region.
 
 [#image-riskprofiler]
 .OpenDRR RiskProfiler
-image::img/opendrr-riskprofiler.png[OpenDRR RiskProfiler, 300]
+image::opendrr-riskprofiler.png[OpenDRR RiskProfiler, 300]
 
 In it's initial release, RiskProfiler will focus primarily on earthquake risk but the intention is to include additional natural hazard risk assessements including flood, wildfire, landslides and tsunami.


### PR DESCRIPTION
Add `:imagesdir:` to en/architecture.adoc too, just like how Joost had
added to it to en/overview.adoc.

I think adding `:imagesdir:` to each section (instead of at the top level)
is a great idea as that seems to be the only way for GitHub AsciiDoc
renderer to display the images when viewing individual section files
while having the entire document rendered properly too.

Adjust the image links accordingly so there is no more unloaded image.